### PR TITLE
Add missing dependency on exported config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(eband_local_planner
   src/eband_visualization.cpp
   src/eband_trajectory_controller.cpp
 )
+add_dependencies(eband_local_planner ${eband_local_planner_EXPORTED_TARGETS})
 
 target_link_libraries(eband_local_planner ${catkin_LIBRARIES})
 


### PR DESCRIPTION
This should prevent the error in this repo that was reported in #24 for the ros-autom fork.